### PR TITLE
Bug/83 attributes in safari

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,14 @@ workflows:
       - test-chrome:
           requires:
             - build
-      - test-browserstack:
-          requires:
-            - build
       - test-browserstack-safari:
           requires:
             - build
+      - test-browserstack:
+          requires:
+            - build
+            - test-browserstack-safari
+
   release:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
       - run:
           name: UI Tests
           command: |
-            mvn test -Dtest=!org.testmonkeys.webpages.tests.popups.Js*,!OuterHtmlTests#set_outerHtml -Pbrowser -Dselenium.profile=browserStack -Dbrowser.profile=properties/bs-safari-latest
+            mvn test  -DfailIfNoTests=false -Dtest=!org.testmonkeys.webpages.tests.popups.Js*,!OuterHtmlTests#set_outerHtml -Pbrowser -Dselenium.profile=browserStack -Dbrowser.profile=properties/bs-safari-latest
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ workflows:
       - test-browserstack:
           requires:
             - build
+      - test-browserstack-safari:
+          requires:
+            - build
   release:
     jobs:
       - build:
@@ -255,7 +258,67 @@ jobs:
             echo $MAVEN_RELEASE_VERSION > ~/repo/junit-tests/target/mvnrelease.out
 
       - store_artifacts:
-                path: ~/repo/junit-tests/target
+          path: ~/repo/junit-tests/target
+
+
+  ##################################################################
+  ##
+  ##TEST-BROWSERSTACK Safari
+  ##
+  ##################################################################
+  test-browserstack-safari:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8u141-browsers
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+
+      - checkout
+
+      - restore_cache:
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - maven-repo-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - maven-repo-v1-{{ .Branch }}-
+            - maven-repo-v1-
+
+      - run:
+          name: UI Tests
+          command: |
+            mvn test -Dtest=!org.testmonkeys.webpages.tests.popups.Js*,!OuterHtmlTests#set_outerHtml -Pbrowser -Dselenium.profile=browserStack -Dbrowser.profile=properties/bs-safari-latest
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+
+      - store_test_results:
+          path: ~/junit
+
+      - run:
+          command: |
+            touch ~/repo/junit-tests/target/mvnrelease.out
+            touch ~/repo/junit-tests/target/circleTag.out
+            echo $CIRCLE_TAG > ~/repo/junit-tests/target/circleTag.out
+            export MAVEN_RELEASE_VERSION="$(echo $CIRCLE_TAG | cut -c 2-)"
+            echo $MAVEN_RELEASE_VERSION > ~/repo/junit-tests/target/mvnrelease.out
+
+      - store_artifacts:
+          path: ~/repo/junit-tests/target
 
 
   ##################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
       - run:
           name: UI Tests
           command: |
-            mvn test  -DfailIfNoTests=false -Dtest=!org.testmonkeys.webpages.tests.popups.Js*,!OuterHtmlTests#set_outerHtml -Pbrowser -Dselenium.profile=browserStack -Dbrowser.profile=properties/bs-safari-latest
+            mvn test  -DfailIfNoTests=false -Dtest=!org.testmonkeys.webpages.tests.popups.Js*,!Abstract*,!OuterHtmlTests#set_outerHtml -Pbrowser -Dselenium.profile=browserStack -Dbrowser.profile=properties/bs-safari-latest
 
       - save_cache:
           paths:

--- a/junit-tests/pom.xml
+++ b/junit-tests/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
@@ -99,6 +104,11 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20190722</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>3.8.0</version>
         </dependency>
     </dependencies>
 

--- a/junit-tests/properties/bs-safari-latest
+++ b/junit-tests/properties/bs-safari-latest
@@ -13,7 +13,7 @@
   "browserstack": {
     "local": true,
     "os":"OS X",
-    "osVersion":"Catalina",
+    "osVersion":"Mojave",
     "seleniumVersion":"3.141.59"
   }
 }

--- a/junit-tests/properties/bs-safari-latest
+++ b/junit-tests/properties/bs-safari-latest
@@ -1,0 +1,19 @@
+{
+  "server": "hub-cloud.browserstack.com",
+  "mauiProperties":{
+       "elementTimeout":10,
+       "pageTimeout":10,
+       "timeoutTimeUnit":"SECONDS"
+     },
+  "capabilities": {
+    "browserName": "Safari",
+    "browserstack.debug": true,
+    "browserstack.local": true
+  },
+  "browserstack": {
+    "local": true,
+    "os":"OS X",
+    "osVersion":"Catalina",
+    "seleniumVersion":"3.5.2"
+  }
+}

--- a/junit-tests/properties/bs-safari-latest
+++ b/junit-tests/properties/bs-safari-latest
@@ -14,6 +14,6 @@
     "local": true,
     "os":"OS X",
     "osVersion":"Catalina",
-    "seleniumVersion":"3.5.2"
+    "seleniumVersion":"3.141.59"
   }
 }

--- a/junit-tests/properties/bs-safari-latest
+++ b/junit-tests/properties/bs-safari-latest
@@ -1,7 +1,7 @@
 {
   "server": "hub-cloud.browserstack.com",
   "mauiProperties":{
-       "elementTimeout":10,
+       "elementTimeout":20,
        "pageTimeout":10,
        "timeoutTimeUnit":"SECONDS"
      },

--- a/junit-tests/src/test/java/org/testmonkeys/DriverFactory.java
+++ b/junit-tests/src/test/java/org/testmonkeys/DriverFactory.java
@@ -1,6 +1,7 @@
 package org.testmonkeys;
 
 import com.browserstack.local.Local;
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.json.JSONObject;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -71,6 +72,7 @@ public class DriverFactory {
 
         switch (webDriverName){
             case "ChromeDriver":
+                WebDriverManager.chromedriver().setup();
                 return new ChromeDriver(capabilities);
             default:
                 throw new IllegalArgumentException("WebDriver "+webDriverName+" is not yet supported");

--- a/junit-tests/src/test/java/org/testmonkeys/DriverFactory.java
+++ b/junit-tests/src/test/java/org/testmonkeys/DriverFactory.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
 
 import java.net.URL;
 import java.util.HashMap;
@@ -74,6 +76,11 @@ public class DriverFactory {
             case "ChromeDriver":
                 WebDriverManager.chromedriver().setup();
                 return new ChromeDriver(capabilities);
+            case "Safari":
+                SafariOptions safariOptions = new SafariOptions();
+
+
+                return new SafariDriver(safariOptions);
             default:
                 throw new IllegalArgumentException("WebDriver "+webDriverName+" is not yet supported");
         }

--- a/maui/src/main/java/org/testmonkeys/maui/pageobjects/elements/html/HtmlElement.java
+++ b/maui/src/main/java/org/testmonkeys/maui/pageobjects/elements/html/HtmlElement.java
@@ -27,17 +27,22 @@ public class HtmlElement {
      * @return List of HtmlAttribute
      */
     public List<HtmlAttribute> getAttributes() {
-        Object result = new ExecuteJSScript(component, GET_ATTRIBUTE).execute();
+        Object jsResult = new ExecuteJSScript(component, GET_ATTRIBUTE).execute();
 
-        List<HtmlAttribute> attributes = new ArrayList<>();
+        Map<String, String> result;
         try {
-            ArrayList<Map<String, String>> elementAttributes = (ArrayList<Map<String, String>>) result;
-            for (Map<String, String> elementAttribute : elementAttributes) {
-                attributes.add(getAttribute(elementAttribute));
-            }
-        } catch (Exception e) {
-            throw new JSInteractionException("Could not parse annotations", e);
+            result = (Map<String, String>) jsResult;
+        } catch (ClassCastException e) {
+            throw new JSInteractionException("Could not parse attributes object", e);
         }
+        List<HtmlAttribute> attributes = new ArrayList<>();
+             for (String keys : result.keySet()) {
+                 HtmlAttribute attribute = new HtmlAttribute();
+                 attribute.setName(keys);
+                 attribute.setValue(result.get(keys));
+                attributes.add(attribute);
+            }
+
 
         return attributes;
     }
@@ -52,26 +57,6 @@ public class HtmlElement {
         return component.find().getAttribute(attributeName);
     }
 
-    /**
-     * Parses the HashMap of each attribute and builds an the HtmlAttribute model
-     *
-     * @param attributeDetails hash map of attribute properties
-     * @return HtmlAttribute
-     */
-    private HtmlAttribute getAttribute(Map<String, String> attributeDetails) {
-        HtmlAttribute attribute = new HtmlAttribute();
-        if (attributeDetails.containsKey("name")) {
-            attribute.setName(attributeDetails.get("name"));
-        } else {
-            throw new JSInteractionException("Could not understand the attribute list");
-        }
-
-        if (attributeDetails.containsKey("value")) {
-            attribute.setValue(attributeDetails.get("value"));
-        }
-
-        return attribute;
-    }
 
     /**
      * Gets the computed style of the element. This will include both the style declared on the element

--- a/maui/src/main/resources/javaScript/htmlElement/getAttributes.js
+++ b/maui/src/main/resources/javaScript/htmlElement/getAttributes.js
@@ -1,3 +1,9 @@
-function fun(element) {
-    return element.attributes;
+function fun(element){
+    var hash={};
+    var atts=element.attributes;
+    for (i = 0; i < atts.length; i++){
+        var att = atts[i];
+        hash[att.nodeName]=att.nodeValue;
+    };
+    return hash;
 }


### PR DESCRIPTION
Fixes bug #83 - Get Attributes fails in safari and implements #86 Incorporate Driver Manager - to be able to test a bit easier on local machines. Adding pipeline job to run tests on safari, with exclusion for Popup tests, as they currently fail on safari, and HtmlElement.setOuterHtml test as that also fails on safari (outer html is readonly on safari)